### PR TITLE
Error code patching

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,12 @@ test:
     - echo 'no tests, only deploy!'
 
 deployment:
-  demo:
-    branch: circle-ci-dev
+  deploy:
+    branch: master
     commands: 
+      - $HOME/$CIRCLE_PROJECT_REPONAME/deploy_infra.sh
+
+  test-deploy:
+    branch: error_code_patching
+    commands:
       - $HOME/$CIRCLE_PROJECT_REPONAME/deploy_infra.sh

--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,3 @@ deployment:
     branch: master
     commands: 
       - $HOME/$CIRCLE_PROJECT_REPONAME/deploy_infra.sh
-
-  test-deploy:
-    branch: error_code_patching
-    commands:
-      - $HOME/$CIRCLE_PROJECT_REPONAME/deploy_infra.sh

--- a/deploy_infra.sh
+++ b/deploy_infra.sh
@@ -2,20 +2,22 @@ echo "go to repo working directory"
 cd $HOME/$CIRCLE_PROJECT_REPONAME
 
 echo "create terraform file"
-ret_var=`java -jar /usr/local/lib/sossity-standalone.jar -c "$HOME/$CIRCLE_PROJECT_REPONAME/tinyconfig.clj" -o "$HOME/$CIRCLE_PROJECT_REPONAME/tinyconfig-terraform.tf.json"`
+java -jar /usr/local/lib/sossity-standalone.jar -c "$HOME/$CIRCLE_PROJECT_REPONAME/tinyconfig.clj" -o "$HOME/$CIRCLE_PROJECT_REPONAME/tinyconfig-terraform.tf.json"
+ret_var=$?
 
-if [ $ret_var -ne 0]; then
+if [ $ret_var -ne 0 ]; then
   echo "failed to generate terraform config.  Abort mission!"
   exit $ret_var
 fi
 
 #  it has a bug, null is the value of the subscribers.  this breaks things so remove it
 #  this bug should be going away soon so we're not super worried about it
-`sed -i /null/d tinyconfig-terraform.tf.json`
+sed -i /null/d tinyconfig-terraform.tf.json
 
 
 echo "regester for remote state management"
-ret_var=`terraform remote config -backend=atlas -backend-config="name=coffeepac/demo-config" -backend-config="access_token=$ATLAS_TOKEN"`
+terraform remote config -backend=atlas -backend-config="name=coffeepac/demo-config" -backend-config="access_token=$ATLAS_TOKEN"
+ret_var=$?
 
 if [ $ret_var -ne 0 ]; then
   echo "Failed to register remote state.  Abort mission!"
@@ -27,18 +29,22 @@ echo $GOOGLE_CREDENTIALS > account.json  #  assume this works
 export GOOGLE_APPLICATION_CREDENTIALS=$HOME/$CIRCLE_PROJECT_REPONAME/account.json  #  assume this works
 
 #  da plan!
-ret_var=`cat <(echo "") | terraform plan`
+cat <(echo "") | terraform plan
+ret_var=$?
 
 if [ $ret_var -eq 0 ]; then
   #  da execution
-  ret_var=`cat <(echo "") | terraform apply`
+  cat <(echo "") | terraform apply
+  ret_var=$?
 fi
 
 echo "always save the state no matter what happened above"
-tf_state_push_ret_var=`terraform remote push`
+terraform remote push
+tf_state_push_ret_var=$?
 
 echo "and save the terraform file as well"
-tf_conf_push_ret_var=`sudo /opt/google-cloud-sdk/bin/gsutil cp tinyconfig-terraform.tf.json gs://build-artifacts-public-eu/tinyconfig-terraform.tf.json`
+sudo /opt/google-cloud-sdk/bin/gsutil cp tinyconfig-terraform.tf.json gs://build-artifacts-public-eu/tinyconfig-terraform.tf.json
+tf_conf_push_ret_var=$?
 
 exit $(($ret_var || $$ $tf_state_push_ret_var || $tf_conf_push_ret_var ))
 

--- a/deploy_infra.sh
+++ b/deploy_infra.sh
@@ -2,26 +2,44 @@ echo "go to repo working directory"
 cd $HOME/$CIRCLE_PROJECT_REPONAME
 
 echo "create terraform file"
-java -jar /usr/local/lib/sossity-standalone.jar -c "$HOME/$CIRCLE_PROJECT_REPONAME/tinyconfig.clj" -o "$HOME/$CIRCLE_PROJECT_REPONAME/tinyconfig-terraform.tf.json"
+ret_var=`java -jar /usr/local/lib/sossity-standalone.jar -c "$HOME/$CIRCLE_PROJECT_REPONAME/tinyconfig.clj" -o "$HOME/$CIRCLE_PROJECT_REPONAME/tinyconfig-terraform.tf.json"`
+
+if [ $ret_var -ne 0]; then
+  echo "failed to generate terraform config.  Abort mission!"
+  exit $ret_var
+fi
 
 #  it has a bug, null is the value of the subscribers.  this breaks things so remove it
-sed -i /null/d tinyconfig-terraform.tf.json
+#  this bug should be going away soon so we're not super worried about it
+`sed -i /null/d tinyconfig-terraform.tf.json`
+
 
 echo "regester for remote state management"
-terraform remote config -backend=atlas -backend-config="name=coffeepac/demo-config" -backend-config="access_token=$ATLAS_TOKEN"
+ret_var=`terraform remote config -backend=atlas -backend-config="name=coffeepac/demo-config" -backend-config="access_token=$ATLAS_TOKEN"`
+
+if [ $ret_var -ne 0 ]; then
+  echo "Failed to register remote state.  Abort mission!"
+  exit $ret_var
+fi
 
 echo "create the account file"
-echo $GOOGLE_CREDENTIALS > account.json
-export GOOGLE_APPLICATION_CREDENTIALS=$HOME/$CIRCLE_PROJECT_REPONAME/account.json
+echo $GOOGLE_CREDENTIALS > account.json  #  assume this works
+export GOOGLE_APPLICATION_CREDENTIALS=$HOME/$CIRCLE_PROJECT_REPONAME/account.json  #  assume this works
 
 #  da plan!
-cat <(echo "") | terraform plan
+ret_var=`cat <(echo "") | terraform plan`
 
-#  da execution
-cat <(echo "") | terraform apply
+if [ $ret_var -eq 0 ]; then
+  #  da execution
+  ret_var=`cat <(echo "") | terraform apply`
+fi
 
 echo "always save the state no matter what happened above"
-terraform remote push
+tf_state_push_ret_var=`terraform remote push`
 
 echo "and save the terraform file as well"
-sudo /opt/google-cloud-sdk/bin/gsutil cp tinyconfig-terraform.tf.json gs://build-artifacts-public-eu/tinyconfig-terraform.tf.json
+tf_conf_push_ret_var=`sudo /opt/google-cloud-sdk/bin/gsutil cp tinyconfig-terraform.tf.json gs://build-artifacts-public-eu/tinyconfig-terraform.tf.json`
+
+exit $(($ret_var || $$ $tf_state_push_ret_var || $tf_conf_push_ret_var ))
+
+

--- a/deploy_infra.sh
+++ b/deploy_infra.sh
@@ -46,6 +46,6 @@ echo "and save the terraform file as well"
 sudo /opt/google-cloud-sdk/bin/gsutil cp tinyconfig-terraform.tf.json gs://build-artifacts-public-eu/tinyconfig-terraform.tf.json
 tf_conf_push_ret_var=$?
 
-exit $(($ret_var || $$ $tf_state_push_ret_var || $tf_conf_push_ret_var ))
+exit $(($ret_var || $tf_state_push_ret_var || $tf_conf_push_ret_var ))
 
 


### PR DESCRIPTION
if we fail to generate the terraform config or fail to pull down
the remote terraform state, eject immediately

if we fail plan don't attempt apply but do save state and config file.

if we fail apply, save state and config file

if any of the error values are set, set the overall exit code to
1 so that circleci goes red.
