### PR TITLE
Terraform upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # demo-config
 demonstration configuration for end-to-end build/deploy system.
 
-This repo houses three files:
+This repo houses four files:
 - tinyconfig.clj
 - tinyconfig-terraform.tj.json
 - circle.yml
+- jar-specs.txt
 
 tinyconfig.clj describes an infrastructure for executing dataprocessing
 flows.  this file drives sossity, the 22acacia application that drives
@@ -18,9 +19,21 @@ circle.yml tells circle ci what to do and acts as the final orchestrator
 for deploying the infrastructure described in tinyconfig.clj and implied
 in the storage bucket build-artifacts-public-eu.
 
+jar-specs.txt tells this project which versions of the input jars to 
+deploy.  this file has three columns.  the first is the app name which
+doubles as the root of the key to use to download all artifacts from
+google storage.  the next column is a regular expression, as used by
+egrep, and it is applied to the VERSIONS.txt file which is present in
+the root key in google storage (there is already code in this repo to
+download this fie but make sure you do if you are operating outside of
+this project).  this regular expression should return only one record 
+from the VERSIONS.txt file.  that record is the final  segment to the 
+google storage key for which jar to download.  the final column is the 
+name on disk to save the chosen jar file too.
 
 #  accessing remote state locally
-see coffeepac for a valid ATLAS_TOKEN.  Then run the following in an
+see coffeepac for a valid ATLAS_TOKEN, or change who owns the atlas 
+account that this state is stored in.  Then run the following in an
 empty directory:
 
 terraform remote config -backend=atlas -backend-config="name=coffeepac/demo-config" -backend-config="access_token=$ATLAS_TOKEN"

--- a/configure_host.sh
+++ b/configure_host.sh
@@ -1,7 +1,7 @@
 cwd=`pwd`
 
 echo "download and install terraform and custom provider"
-curl https://releases.hashicorp.com/terraform/0.6.8/terraform_0.6.8_linux_amd64.zip -o $HOME/$CIRCLE_PROJECT_REPONAME/terraform.zip
+curl https://releases.hashicorp.com/terraform/0.6.8/terraform_0.6.9_linux_amd64.zip -o $HOME/$CIRCLE_PROJECT_REPONAME/terraform.zip
 sudo unzip $HOME/$CIRCLE_PROJECT_REPONAME/terraform.zip -d /usr/local/bin/
 
 echo "ensure gsutil is installed"
@@ -14,9 +14,9 @@ export GOOGLE_APPLICATION_CREDENTIALS=$HOME/$CIRCLE_PROJECT_REPONAME/account.jso
 echo "auth the local sudo gcloud"
 sudo /opt/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file $HOME/$CIRCLE_PROJECT_REPONAME/account.json
 
-echo "download tip google provider - we need code that's only in tip right now"
-sudo /opt/google-cloud-sdk/bin/gsutil cp gs://build-artifacts-public-eu/terraform-provider-google /usr/local/bin/terraform-provider-google
-sudo chmod +x /usr/local/bin/terraform-provider-google
+echo "download googlebigquery provider"
+sudo /opt/google-cloud-sdk/bin/gsutil cp gs://build-artifacts-public-eu/terraform-provider-googlebigquery /usr/local/bin/terraform-provider-googlebigquery
+sudo chmod +x /usr/local/bin/terraform-provider-googlebigquery
 
 echo "download googlecli provider"
 sudo /opt/google-cloud-sdk/bin/gsutil cp gs://build-artifacts-public-eu/terraform-provider-googlecli /usr/local/bin/terraform-provider-googlecli


### PR DESCRIPTION
- terraform version 0.6.8 -> 0.6.9
- new provider:  terraform-provider-googlebiguery
  -  only provides bigquery resources
  -  no longer need to build/maintain our fork of terraform

also includes a README doc update for VERSIONS.txt stuff.
